### PR TITLE
Add Docker multi-stage builds and compose configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Gradle & build artifacts
+.gradle/
+build/
+app/build/
+
+# IDE & OS metadata
+*.iml
+*.ipr
+*.iws
+.idea/
+.vscode/
+.DS_Store
+
+# Logs & temp files
+*.log
+*.tmp
+*.swp
+
+# Node/other caches
+node_modules/

--- a/Dockerfile.api1
+++ b/Dockerfile.api1
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /workspace
+
+COPY gradle gradle
+COPY gradlew .
+COPY settings.gradle .
+COPY gradle.properties .
+COPY app app
+
+RUN chmod +x gradlew \
+    && ./gradlew :app:bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+COPY --from=build /workspace/app/build/libs/app-0.0.1-SNAPSHOT.jar app.jar
+
+ENV SPRING_MAIN_APPLICATION_CLASS=com.example.demo.SpringMybatisSampleApplication \
+    JAVA_OPTS=""
+
+EXPOSE 8080
+
+ENTRYPOINT ["sh", "-c", "exec java -Dspring.main.application-class=${SPRING_MAIN_APPLICATION_CLASS} ${JAVA_OPTS} -jar app.jar"]

--- a/Dockerfile.api2
+++ b/Dockerfile.api2
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /workspace
+
+COPY gradle gradle
+COPY gradlew .
+COPY settings.gradle .
+COPY gradle.properties .
+COPY app app
+
+RUN chmod +x gradlew \
+    && ./gradlew :app:bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+COPY --from=build /workspace/app/build/libs/app-0.0.1-SNAPSHOT.jar app.jar
+
+ENV SPRING_MAIN_APPLICATION_CLASS=com.example.demo.api2.Api2Application \
+    SERVER_PORT=8081 \
+    SPRING_PROFILES_ACTIVE=api2 \
+    JAVA_OPTS=""
+
+EXPOSE 8081
+
+ENTRYPOINT ["sh", "-c", "exec java -Dspring.main.application-class=${SPRING_MAIN_APPLICATION_CLASS} ${JAVA_OPTS} -jar app.jar"]

--- a/Dockerfile.batch
+++ b/Dockerfile.batch
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /workspace
+
+COPY gradle gradle
+COPY gradlew .
+COPY settings.gradle .
+COPY gradle.properties .
+COPY app app
+
+RUN chmod +x gradlew \
+    && ./gradlew :app:bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+COPY --from=build /workspace/app/build/libs/app-0.0.1-SNAPSHOT.jar app.jar
+
+ENV SPRING_MAIN_APPLICATION_CLASS=com.example.demo.batch.BatchApplication \
+    SPRING_BATCH_JOB_NAME=sampleJob \
+    JAVA_OPTS=""
+
+ENTRYPOINT ["sh", "-c", "exec java -Dspring.main.application-class=${SPRING_MAIN_APPLICATION_CLASS} ${JAVA_OPTS} -jar app.jar --spring.batch.job.names=${SPRING_BATCH_JOB_NAME}"]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,37 @@ gradle wrapper
 
 アプリケーションが起動すると `http://localhost:8080/api/users` にユーザー API が公開されます。
 
+## Docker でのビルドと起動
+
+Docker を利用する場合は、リポジトリ直下に用意したマルチステージビルド用の Dockerfile 群と `docker-compose.yml` を利用できます。
+
+### コンテナイメージのビルド
+
+```bash
+docker compose build
+```
+
+### コンテナの起動
+
+```bash
+docker compose up -d
+```
+
+起動後は以下のエンドポイントが公開されます。
+
+- API1: `http://localhost:8080`
+- API2: `http://localhost:8081`
+
+バッチコンテナは `SPRING_BATCH_JOB_NAME` で指定した Spring Batch ジョブ（デフォルトは `userImportJob`）を実行して終了します。
+
+MySQL のデータ永続化には `mysql-data` ボリュームを利用しています。環境変数（DB 接続先や API2 のポート、Spring Profile など）は `docker-compose.yml` の `environment` セクションを調整してください。
+
+### 停止と後片付け
+
+```bash
+docker compose down -v
+```
+
 ## サンプル API
 
 | メソッド | パス | 説明 |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+version: "3.9"
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: sample-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: sample_db
+      MYSQL_USER: sample_user
+      MYSQL_PASSWORD: sample_password
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+
+  api1:
+    build:
+      context: .
+      dockerfile: Dockerfile.api1
+    environment:
+      SPRING_MAIN_APPLICATION_CLASS: com.example.demo.SpringMybatisSampleApplication
+      SPRING_PROFILES_ACTIVE: api1
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/sample_db?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8
+      SPRING_DATASOURCE_USERNAME: sample_user
+      SPRING_DATASOURCE_PASSWORD: sample_password
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mysql
+
+  api2:
+    build:
+      context: .
+      dockerfile: Dockerfile.api2
+    environment:
+      SPRING_MAIN_APPLICATION_CLASS: com.example.demo.api2.Api2Application
+      SPRING_PROFILES_ACTIVE: api2
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/sample_db?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8
+      SPRING_DATASOURCE_USERNAME: sample_user
+      SPRING_DATASOURCE_PASSWORD: sample_password
+      SERVER_PORT: 8081
+    ports:
+      - "8081:8081"
+    depends_on:
+      - mysql
+
+  batch:
+    build:
+      context: .
+      dockerfile: Dockerfile.batch
+    environment:
+      SPRING_MAIN_APPLICATION_CLASS: com.example.demo.batch.BatchApplication
+      SPRING_PROFILES_ACTIVE: batch
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/sample_db?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8
+      SPRING_DATASOURCE_USERNAME: sample_user
+      SPRING_DATASOURCE_PASSWORD: sample_password
+      SPRING_BATCH_JOB_NAME: userImportJob
+    depends_on:
+      - mysql
+
+volumes:
+  mysql-data:


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfiles for the API and batch applications that build the jar with Gradle and set the appropriate entrypoints
- create a docker-compose setup covering two API containers, the batch job, and a MySQL instance, and add a .dockerignore for leaner images
- document container build, startup, and teardown steps in the README

## Testing
- ./gradlew test *(fails: Gradle wrapper jar is not included in the repository as noted in the README)*

------
https://chatgpt.com/codex/tasks/task_e_68e240b3bbcc832c892a040fc8d1905a